### PR TITLE
Add option to customise fit

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ try {
   - __height__ [number] - image thumbnail height.
   - __responseType__ ['buffer' || 'base64'] - response output type. Default = 'buffer'
   - __jpegOptions__ [0-100] - Example: { force:true, quality:100 }
+  - __fit__ [string] - method by which the image should fit the width/height. Default = contain
 
 ### Examples
 ```js


### PR DESCRIPTION
The `sharp` [resize](https://sharp.pixelplumbing.com/api-resize#resize) method has a `fit` parameter which currently is set as `contain`.
This PR adds the ability to change the fit to any supported values (cover, contain, fill, inside, outside) but keeps `contain` as the default (if not specified) for backward compatibility
