### PR TITLE
Upgrade Sharp version request

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "axios": "^0.21.1",
     "image-size": "^1.0.0",
-    "sharp": "^0.28",
+    "sharp": "^0.30.4",
     "validator": "^13.0.0"
   },
   "jest": {


### PR DESCRIPTION
Can you please update the Sharp version in your dependencies?
Prebuilt sharp and libvips binaries have been provided for macOS on ARM64 since sharp v0.29.0. We can't run image-thumbnail in the latest Mac 